### PR TITLE
Update88

### DIFF
--- a/DigitalReference.ttl
+++ b/DigitalReference.ttl
@@ -474,7 +474,7 @@ time:before rdf:type owl:ObjectProperty ,
 ###  http://www.w3.org/2006/time#day_of_week
 time:day_of_week rdf:type owl:ObjectProperty ;
                  rdfs:domain time:General_Date_Time_Description ;
-                 rdfs:range time:day_of_week .
+                 rdfs:range time:DayOfWeek .
 
 
 ###  http://www.w3.org/2006/time#hasBeginning
@@ -9687,9 +9687,9 @@ ecsel-dr-DF:demand_priority rdf:type owl:DatatypeProperty ;
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#has_order_position
-ecsel-dr-DF:has_order_position rdf:type owl:DatatypeProperty ;
-                               rdfs:subPropertyOf owl:topDataProperty ;
-                               rdfs:range rdfs:Literal .
+ecsel-dr-DF:has_order_position_value rdf:type owl:DatatypeProperty ;
+                                     rdfs:subPropertyOf owl:topDataProperty ;
+                                     rdfs:range rdfs:Literal .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#lot_ID
@@ -14315,14 +14315,10 @@ Detailed guidance about working with time zones is given in http://www.w3.org/TR
                skos:scopeNote "In this implementation TimeZone has no properties defined. It should be thought of as an 'abstract' superclass of all specific timezone implementations." .
 
 
-###  http://www.w3.org/2006/time#day_of_week
-time:day_of_week rdf:type owl:Class ;
+###  http://www.w3.org/2006/time#DayOfWeek
+time:DayOfWeek rdf:type owl:Class ;
                  rdfs:subClassOf dr:Time_Lobe .
 
-
-###  http://www.w3.org/2006/time#time_zone
-time:time_zone rdf:type owl:Class ;
-               rdfs:subClassOf dr:Time_Lobe .
 
 
 ###  http://www.w3.org/TR/vocab-ssn-ext/Observation_Collection
@@ -19712,14 +19708,14 @@ ecsel-dr-DF:Best_Promised_Delivery_Date rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Complete_Delivery
 ecsel-dr-DF:Complete_Delivery rdf:type owl:Class ;
                               rdfs:subClassOf ecsel-dr-DF:Delivery_Concept ;
-                              rdfs:comment "The normal case is that an order is completely delivered."^^rdfs:Literal ;
+                              rdfs:comment "The normal case is that an order is completely delivered." ;
                               rdfs:label "Complete Delivery"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Confirmed_Delivery_Date
 ecsel-dr-DF:Confirmed_Delivery_Date rdf:type owl:Class ;
                                     rdfs:subClassOf ecsel-dr-DF:Date ;
-                                    rdfs:comment "The CDD is the committed date for order delivery that is communicated to the costumer. It depends on the communication strategy between manufacturer and customer. For instance, the CDD is the PDD if order repromising takes place in the same frequency as the update interval of the CDD."^^rdfs:Literal ;
+                                    rdfs:comment "The CDD is the committed date for order delivery that is communicated to the costumer. It depends on the communication strategy between manufacturer and customer. For instance, the CDD is the PDD if order repromising takes place in the same frequency as the update interval of the CDD." ;
                                     rdfs:label "Confirmed Delivery Date"@en .
 
 
@@ -19734,7 +19730,7 @@ ecsel-dr-DF:Customer_Class rdf:type owl:Class ;
 ecsel-dr-DF:Customer_Order rdf:type owl:Class ;
                            rdfs:subClassOf dr:Order ;
                            owl:disjointWith ecsel-dr-DF:Replenishment_Order ;
-                           rdfs:comment "This is an order that is initiated by a customer."^^rdfs:Literal ;
+                           rdfs:comment "This is an order that is initiated by a customer." ;
                            rdfs:label "Customer Order"@en .
 
 
@@ -19742,7 +19738,7 @@ ecsel-dr-DF:Customer_Order rdf:type owl:Class ;
 ecsel-dr-DF:Date rdf:type owl:Class ;
                  rdfs:subClassOf dr:Time_Lobe ;
                  rdfs:comment "Additional lobe: Supply Chain"@en ,
-                              "The availability date defines the point in time when the supply is available to the customer. It can be distinguished between different availability dates. Not all availability dates are communicated to the customer."^^rdfs:Literal .
+                              "The availability date defines the point in time when the supply is available to the customer. It can be distinguished between different availability dates. Not all availability dates are communicated to the customer." .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Delivery_Concept
@@ -19755,7 +19751,7 @@ ecsel-dr-DF:Delivery_Concept rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Delivery_Date
 ecsel-dr-DF:Delivery_Date rdf:type owl:Class ;
                           rdfs:subClassOf ecsel-dr-DF:Date ;
-                          rdfs:comment "This is the point in time when the customer received the requested order."^^rdfs:Literal ;
+                          rdfs:comment "This is the point in time when the customer received the requested order." ;
                           rdfs:label "Delivery Date"@en .
 
 
@@ -19785,7 +19781,7 @@ ecsel-dr-DF:Demand_Priority rdf:type owl:Class ;
 ecsel-dr-DF:Engineering_Lot rdf:type owl:Class ;
                             rdfs:subClassOf ecsel-dr-DF:Lot ;
                             owl:disjointWith ecsel-dr-DF:Productive_Lot ;
-                            rdfs:comment "An engineering lot requires additional process development efforts and special attention during the production flow. Engineering lots have various functions, thus several engineering lot types can be differentiated."^^rdfs:Literal ;
+                            rdfs:comment "An engineering lot requires additional process development efforts and special attention during the production flow. Engineering lots have various functions, thus several engineering lot types can be differentiated." ;
                             rdfs:label "Engineering Lot"@en .
 
 
@@ -19799,21 +19795,21 @@ ecsel-dr-DF:External_Customer rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Firm_Order_Demand
 ecsel-dr-DF:Firm_Order_Demand rdf:type owl:Class ;
                               rdfs:subClassOf ecsel-dr-DF:Demand_Class ;
-                              rdfs:comment "This is a special demand class that is used for demand that is required to fulfill already committed/accepted orders."^^rdfs:Literal ;
+                              rdfs:comment "This is a special demand class that is used for demand that is required to fulfill already committed/accepted orders." ;
                               rdfs:label "Firm Order Demand"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#First_Promised_Delivery_Date
 ecsel-dr-DF:First_Promised_Delivery_Date rdf:type owl:Class ;
                                          rdfs:subClassOf ecsel-dr-DF:Date ;
-                                         rdfs:comment "Initially, the FPD is set for an order delivery within the online order confirmation process."^^rdfs:Literal ;
+                                         rdfs:comment "Initially, the FPD is set for an order delivery within the online order confirmation process." ;
                                          rdfs:label "First Promised Delivery Date"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Forecasted_Demand
 ecsel-dr-DF:Forecasted_Demand rdf:type owl:Class ;
                               rdfs:subClassOf ecsel-dr-DF:Demand_Class ;
-                              rdfs:comment "This is a special demand class that is used for the projection of future demand."^^rdfs:Literal ;
+                              rdfs:comment "This is a special demand class that is used for the projection of future demand." ;
                               rdfs:label "Forecasted Demand"@en .
 
 
@@ -19826,7 +19822,7 @@ ecsel-dr-DF:Internal_Customer rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Inventory_Replenishment_Demand
 ecsel-dr-DF:Inventory_Replenishment_Demand rdf:type owl:Class ;
                                            rdfs:subClassOf ecsel-dr-DF:Demand_Class ;
-                                           rdfs:comment "This is a special demand class that is used for replenishment of safety stock."^^rdfs:Literal ;
+                                           rdfs:comment "This is a special demand class that is used for replenishment of safety stock." ;
                                            rdfs:label "Inventory Replenishment Demand"@en .
 
 
@@ -19858,7 +19854,7 @@ LOCATIONS are fundamental to managing supply chain efficiency, tracking material
 ecsel-dr-DF:Lot rdf:type owl:Class ;
                 owl:equivalentClass ecsel-dr-SO:Lot ;
                 rdfs:subClassOf dr:Semiconductor_Production_Lobe ;
-                rdfs:comment "A lot is a set of wafers, substrates or modules that travel together through the FE or BE fab in order to fulfill a certain order."^^rdfs:Literal .
+                rdfs:comment "A lot is a set of wafers, substrates or modules that travel together through the FE or BE fab in order to fulfill a certain order." .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Order_Position
@@ -19872,14 +19868,14 @@ ecsel-dr-DF:Order_Position rdf:type owl:Class ;
 ecsel-dr-DF:Partial_Delivery rdf:type owl:Class ;
                              rdfs:subClassOf ecsel-dr-DF:Delivery_Concept ;
                              owl:disjointWith ecsel-dr-DF:Split_Delivery ;
-                             rdfs:comment "It can be allowed that only parts of an order position of an order are delivered. Therefore, the customer is willing to waive parts of quantity belonging to an order position."^^rdfs:Literal ;
+                             rdfs:comment "It can be allowed that only parts of an order position of an order are delivered. Therefore, the customer is willing to waive parts of quantity belonging to an order position." ;
                              rdfs:label "Partial Delivery"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Period
 ecsel-dr-DF:Period rdf:type owl:Class ;
                    rdfs:subClassOf ecsel-dr-DF:Time_Interval ;
-                   rdfs:comment "The concept period displays the sub unit of the planning horizon."^^rdfs:Literal .
+                   rdfs:comment "The concept period displays the sub unit of the planning horizon." .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Planning_Period
@@ -19899,14 +19895,14 @@ ecsel-dr-DF:Planning_Window rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Product_Aggregate
 ecsel-dr-DF:Product_Aggregate rdf:type owl:Class ;
                               rdfs:subClassOf dr:Product_Lobe ;
-                              rdfs:comment "The concept product aggregate is used to group different products based on certain criteria. The grouping criteria depend on the planning purpose (e.g. controlling, production). It is a certain view (external or internal) on a set of products."^^rdfs:Literal ;
+                              rdfs:comment "The concept product aggregate is used to group different products based on certain criteria. The grouping criteria depend on the planning purpose (e.g. controlling, production). It is a certain view (external or internal) on a set of products." ;
                               rdfs:label "Product Aggregate"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Product_Hierarchy
 ecsel-dr-DF:Product_Hierarchy rdf:type owl:Class ;
                               rdfs:subClassOf dr:Product_Lobe ;
-                              rdfs:comment "The concept characterizes the top-down and bottom-up relationship between different product aggregates. It organizes the product aggregates according to defined criteria."^^rdfs:Literal ;
+                              rdfs:comment "The concept characterizes the top-down and bottom-up relationship between different product aggregates. It organizes the product aggregates according to defined criteria." ;
                               rdfs:label "Product Hierarchy"@en .
 
 
@@ -19920,28 +19916,28 @@ ecsel-dr-DF:Production_Strategy rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Productive_Lot
 ecsel-dr-DF:Productive_Lot rdf:type owl:Class ;
                            rdfs:subClassOf ecsel-dr-DF:Lot ;
-                           rdfs:comment "A productive lot is created to fulfill a customer demand. The production process is carried out as it is defined during the production development phase."^^rdfs:Literal ;
+                           rdfs:comment "A productive lot is created to fulfill a customer demand. The production process is carried out as it is defined during the production development phase." ;
                            rdfs:label "Productive Lot"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Promised_Delivery_Date
 ecsel-dr-DF:Promised_Delivery_Date rdf:type owl:Class ;
                                    rdfs:subClassOf ecsel-dr-DF:Date ;
-                                   rdfs:comment "This is the date for which eventually partial order delivery is confirmed. The PDD date can be changed over time. Within the repromising process there are typically different PDDs available."^^rdfs:Literal ;
+                                   rdfs:comment "This is the date for which eventually partial order delivery is confirmed. The PDD date can be changed over time. Within the repromising process there are typically different PDDs available." ;
                                    rdfs:label "Promised Delivery Date"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Replenishment_Order
 ecsel-dr-DF:Replenishment_Order rdf:type owl:Class ;
                                 rdfs:subClassOf dr:Order ;
-                                rdfs:comment "This is an order that is initiated by an internal request of the semiconductor manufacturer to produce the order according to a MTS strategy. The replenishment order can be divided into different sub order types, depending on the purpose of order creation."^^rdfs:Literal ;
+                                rdfs:comment "This is an order that is initiated by an internal request of the semiconductor manufacturer to produce the order according to a MTS strategy. The replenishment order can be divided into different sub order types, depending on the purpose of order creation." ;
                                 rdfs:label "Replenishment Order"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Requested_Delivery_Date
 ecsel-dr-DF:Requested_Delivery_Date rdf:type owl:Class ;
                                     rdfs:subClassOf ecsel-dr-DF:Date ;
-                                    rdfs:comment "The RDD is the point in time when the customer wants to get the order."^^rdfs:Literal ;
+                                    rdfs:comment "The RDD is the point in time when the customer wants to get the order." ;
                                     rdfs:label "Requested Delivery Date"@en .
 
 
@@ -19951,13 +19947,13 @@ ecsel-dr-DF:Route rdf:type owl:Class ;
                                       ecsel-dr-SO:Route ;
                   rdfs:subClassOf dr:Semiconductor_Production_Lobe ;
                   rdfs:comment "Additional lobes: Semiconductor Production"@en ,
-                               "The term route can be considered on different levels. In the present situation, a route is associated with a product and describes its production flow on the production network level."^^rdfs:Literal .
+                               "The term route can be considered on different levels. In the present situation, a route is associated with a product and describes its production flow on the production network level." .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Split_Delivery
 ecsel-dr-DF:Split_Delivery rdf:type owl:Class ;
                            rdfs:subClassOf ecsel-dr-DF:Delivery_Concept ;
-                           rdfs:comment "It can be allowed that order positions of an order are delivered in several portions."^^rdfs:Literal ;
+                           rdfs:comment "It can be allowed that order positions of an order are delivered in several portions." ;
                            rdfs:label "Split Delivery"@en .
 
 
@@ -20004,7 +20000,7 @@ ecsel-dr-DF:Time_Interval rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-DF#Assemble_To_Order_(ATO)
 <http://www.w3id.org/ecsel-dr-DF#Assemble_To_Order_(ATO)> rdf:type owl:Class ;
                                                           rdfs:subClassOf ecsel-dr-DF:Production_Strategy ;
-                                                          rdfs:comment "In the case of ATO, products are produced forecast-driven until the point right before it comes to the assembly. Starting from there, the production continues based on a customer order."^^rdfs:Literal ;
+                                                          rdfs:comment "In the case of ATO, products are produced forecast-driven until the point right before it comes to the assembly. Starting from there, the production continues based on a customer order." ;
                                                           rdfs:label "Assemble To Order"@en .
 
 
@@ -20012,21 +20008,21 @@ ecsel-dr-DF:Time_Interval rdf:type owl:Class ;
 <http://www.w3id.org/ecsel-dr-DF#Bill_Of_Material_(BOM)> rdf:type owl:Class ;
                                                          owl:equivalentClass ecsel-dr-Planning:Bill_Of_Material ;
                                                          rdfs:subClassOf dr:Product_Lobe ;
-                                                         rdfs:comment "A BOM describes components or rather semi-finished products that are part of the finished product. Substitution, often associated with binning, is based on the possibility that alternative items might be used to finish a process step. This leads to the notion of alternative BOMs."^^rdfs:Literal ;
+                                                         rdfs:comment "A BOM describes components or rather semi-finished products that are part of the finished product. Substitution, often associated with binning, is based on the possibility that alternative items might be used to finish a process step. This leads to the notion of alternative BOMs." ;
                                                          rdfs:label "Bill Of Material (BOM)"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Make_To_Order_(MTO)
 <http://www.w3id.org/ecsel-dr-DF#Make_To_Order_(MTO)> rdf:type owl:Class ;
                                                       rdfs:subClassOf ecsel-dr-DF:Production_Strategy ;
-                                                      rdfs:comment "This is a strategy where production is initiated to fulfill specific customer orders. This strategy is characterized by an order-driven production."^^rdfs:Literal ;
+                                                      rdfs:comment "This is a strategy where production is initiated to fulfill specific customer orders. This strategy is characterized by an order-driven production." ;
                                                       rdfs:label "Make To Order"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-DF#Make_To_Stock_(MTS)
 <http://www.w3id.org/ecsel-dr-DF#Make_To_Stock_(MTS)> rdf:type owl:Class ;
                                                       rdfs:subClassOf ecsel-dr-DF:Production_Strategy ;
-                                                      rdfs:comment "This is a strategy where production is driven by the replenishment of inventories at specific locations. Products are produced forecast-driven until they are completely finished in the case of MTS."^^rdfs:Literal ;
+                                                      rdfs:comment "This is a strategy where production is driven by the replenishment of inventories at specific locations. Products are produced forecast-driven until they are completely finished in the case of MTS." ;
                                                       rdfs:label "Make To Stock"@en .
 
 
@@ -22501,7 +22497,7 @@ ecsel-dr-Planning:Yield rdf:type owl:Class ;
 <http://www.w3id.org/ecsel-dr-Planning-DF#Allocation_Plan> rdf:type owl:Class ;
                                                            rdfs:subClassOf dr:Plan ;
                                                            owl:disjointWith <http://www.w3id.org/ecsel-dr-Planning-DF#Master_Plan> ;
-                                                           rdfs:comment "An allocation plan is a special plan, which deals with assigning ATP quantities to a customer or a customer class."^^rdfs:Literal ;
+                                                           rdfs:comment "An allocation plan is a special plan, which deals with assigning ATP quantities to a customer or a customer class." ;
                                                            rdfs:label "Allocation Plan"@en .
 
 
@@ -22515,7 +22511,7 @@ ecsel-dr-Planning:Yield rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-Planning-DF#Master_Plan
 <http://www.w3id.org/ecsel-dr-Planning-DF#Master_Plan> rdf:type owl:Class ;
                                                        rdfs:subClassOf dr:Plan ;
-                                                       rdfs:comment "A master plan is a specific plan which determines which quantity resulting from confirmed orders and from forecasted demand should be completed in which location in which period of the planning horizon. Moreover, outsourcing decisions have to be represented in master plans."^^rdfs:Literal ;
+                                                       rdfs:comment "A master plan is a specific plan which determines which quantity resulting from confirmed orders and from forecasted demand should be completed in which location in which period of the planning horizon. Moreover, outsourcing decisions have to be represented in master plans." ;
                                                        rdfs:label "Master Plan"@en .
 
 
@@ -22536,14 +22532,14 @@ ecsel-dr-Planning:Yield rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-Planning-DF#Order_Delivery_Plan
 <http://www.w3id.org/ecsel-dr-Planning-DF#Order_Delivery_Plan> rdf:type owl:Class ;
                                                                rdfs:subClassOf dr:Plan ;
-                                                               rdfs:comment "This is the result of the order promise or repromise process for different sets of orders taking into account an allocation policy and the supply and allocation situation. Different order promising variants can be distinguished, for instance online order promising, batch order promising, and hybrid order promising. The same is true of repromising."^^rdfs:Literal ;
+                                                               rdfs:comment "This is the result of the order promise or repromise process for different sets of orders taking into account an allocation policy and the supply and allocation situation. Different order promising variants can be distinguished, for instance online order promising, batch order promising, and hybrid order promising. The same is true of repromising." ;
                                                                rdfs:label "Order Delivery Plan"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-DF#Order_Promising
 <http://www.w3id.org/ecsel-dr-Planning-DF#Order_Promising> rdf:type owl:Class ;
                                                            rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-DF#Planning> ;
-                                                           rdfs:comment "This concept describes the process to promise an order considering allocation policy as well as supply and allocation situation. The order promising can be distinguished between different variants, for instance online order promising and batch order promising."^^rdfs:Literal ;
+                                                           rdfs:comment "This concept describes the process to promise an order considering allocation policy as well as supply and allocation situation. The order promising can be distinguished between different variants, for instance online order promising and batch order promising." ;
                                                            rdfs:label "Order Promising"@en .
 
 
@@ -24224,8 +24220,7 @@ ecsel-dr-SO:Target_Service_Level rdf:type owl:Class ;
 
 ###  http://www.w3id.org/ecsel-dr-SO#Technology
 ecsel-dr-SO:Technology rdf:type owl:Class ;
-                       rdfs:subClassOf dr:Semiconductor_Development_Lobe ,
-                                       ecsel-dr-SO:Technology ;
+                       rdfs:subClassOf dr:Semiconductor_Development_Lobe ;
                        rdfs:comment "A semiconductor technology is a set of equipment, processes, manufacturing techniques and the related methods and procedures to enable the design & production of components, sub-components and modules."@en ;
                        rdfs:label "Technology"@en .
 

--- a/DigitalReference.ttl
+++ b/DigitalReference.ttl
@@ -160,7 +160,7 @@ owl:maxCardinality rdf:type owl:AnnotationProperty .
 
 ###  http://www.w3.org/2004/02/skos/core#altLabel
 skos:altLabel rdf:type owl:AnnotationProperty ;
-              rdfs:comment "The alternative name of a conept, e.g. a misspelled name,  a concept can have one or more alternative names."@en ;
+              rdfs:comment "The alternative name of a concept, e.g. a misspelled name,  a concept can have one or more alternative names."@en ;
               skos:prefLabel "Alternative Label"@en ;
               ecsel-dr-OOSMP:abbreviation "altLabel"@en ;
               rdfs:subPropertyOf rdfs:label ;
@@ -186,7 +186,7 @@ skos:example rdf:type owl:AnnotationProperty .
 ###  http://www.w3.org/2004/02/skos/core#hiddenLabel
 skos:hiddenLabel rdf:type owl:AnnotationProperty ;
                  skos:prefLabel "Hidden Label"@en ;
-                 ecsel-dr-OOSMP:abbreviation "The hidden name of a conept, e.g. a misspelled name,  a concept can have one or more hidden names."@en ,
+                 ecsel-dr-OOSMP:abbreviation "The hidden name of a concept, e.g. a misspelled name,  a concept can have one or more hidden names."@en ,
                                              "hiddenLabel"@en ;
                  rdfs:subPropertyOf rdfs:label ;
                  rdfs:range xsd:string .
@@ -201,12 +201,12 @@ skos:note rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#preLabel
-skos:preLabel rdf:type owl:AnnotationProperty .
+skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
 skos:prefLabel rdf:type owl:AnnotationProperty ;
-               rdfs:comment "The preferred and commonly used name of a conept, a concept can only have onepreferred name."@en ;
+               rdfs:comment "The preferred and commonly used name of a concept, a concept can only have one preferred name."@en ;
                skos:prefLabel "Preferred Label"@en ;
                ecsel-dr-OOSMP:abbreviation "prefLabel"@en ;
                rdfs:subPropertyOf rdfs:label ;
@@ -1776,7 +1776,7 @@ ecsel-dr-AT:is_vendor_of rdf:type owl:ObjectProperty ;
 
 ###  http://www.w3id.org/ecsel-dr-AT#standardized_by
 ecsel-dr-AT:standardized_by rdf:type owl:ObjectProperty ;
-                            rdfs:label "standarized by"@en .
+                            rdfs:label "standardized by"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-AT#supported_by_technology_or_protocol
@@ -5863,7 +5863,7 @@ ecsel-dr-PMV:is_executed_by_function rdf:type owl:ObjectProperty ;
                                      rdfs:domain <http://purl.org/dc/dcmitype/Software> ;
                                      rdfs:range ecsel-dr-PMV:Function ;
                                      rdfs:comment "Software is executed by a function in a process flow." ;
-                                     rdfs:label "is exectued by function"@en ;
+                                     rdfs:label "is executed by function"@en ;
                                      skos:altLabel "exectu" .
 
 
@@ -6360,7 +6360,7 @@ ecsel-dr-Planning:has_criterias rdf:type owl:ObjectProperty ;
                                 rdfs:domain dr:Planning_Purpose ;
                                 rdfs:range ecsel-dr-Planning:Criteria ;
                                 rdfs:comment "A criterion is assigned to each performance measure that belongs to a PLANNING PURPOSE. Typical criteria are maximization, minimization, i.e. if an optimization problem is considered, or larger or smaller than a prescribed value of the certain performance measure, a so-called target, i.e. if a satisfaction problem is solved. In a multi-criteria setting, the dominance concept for plans is of interest." ;
-                                rdfs:label "has criterias"@en .
+                                rdfs:label "has criteria"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning#has_decision_maker_type
@@ -7112,7 +7112,7 @@ ecsel-dr-Planning:uses_planning_approach rdf:type owl:ObjectProperty ;
 <http://www.w3id.org/ecsel-dr-Power-PWR#has_properties_of> rdf:type owl:ObjectProperty ;
                                                            rdfs:domain <http://www.w3id.org/ecsel-dr-Power-PWR#Semiconductor_Product_Data_Sheet> ;
                                                            rdfs:range <http://www.w3id.org/ecsel-dr-Power-PWR#Amplication_Switching_Device> ;
-                                                           rdfs:label "has propeties of"@en .
+                                                           rdfs:label "has properties of"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Power-PWR#has_voltage
@@ -7124,7 +7124,7 @@ ecsel-dr-Planning:uses_planning_approach rdf:type owl:ObjectProperty ;
 <http://www.w3id.org/ecsel-dr-Power-PWR#has_voltage_drain_voltage> rdf:type owl:ObjectProperty ;
                                                                    rdfs:domain <http://www.w3id.org/ecsel-dr-Power-PWR#The_Application_Voltage> ;
                                                                    rdfs:range <http://www.w3id.org/ecsel-dr-Power-PWR#Drain_Voltage> ;
-                                                                   rdfs:label "is a volatge of"@en .
+                                                                   rdfs:label "is a voltage of"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Power-PWR#has_voltage_equals_or_greater_than
@@ -9389,7 +9389,7 @@ ecsel-dr-CO2Savings:chipcard_manufacturing rdf:type owl:DatatypeProperty ;
 
 ###  http://www.w3id.org/ecsel-dr-CO2Savings#contractor_or_outside_the_company
 ecsel-dr-CO2Savings:contractor_or_outside_the_company rdf:type owl:DatatypeProperty ;
-                                                      rdfs:label "contracter or outside the company"@en .
+                                                      rdfs:label "contractor or outside the company"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-CO2Savings#data_from_50_reference_products
@@ -15651,7 +15651,7 @@ ecsel-dr-AT:Autonomously_Guided_Vehicle rdf:type owl:Class ;
                                                    "FTF"@de ,
                                                    "Fahrerloses Transportfahrzeug"@de ;
                                         skos:definition "Autonomously_Guided_Vehicle - a mobile actuation unit capable of navigating and performing material handling or transport tasks without continuous human control. It comprises propulsion and power systems, onboard sensors and guidance/control software, and interfaces for tasking, telemetry and safety. This class is used to represent actuation, motion control, power consumption/management (e.g., battery, charging), and safety interlocks of autonomous vehicles in supply chain contexts."@en ;
-                                        skos:preLabel "Autonomously Guided Vehicle"@en .
+                                        skos:prefLabel "Autonomously Guided Vehicle"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-AT#B2MML_Based_Service
@@ -22444,7 +22444,8 @@ ecsel-dr-Planning:Semi_Automated rdf:type owl:Class ;
 ###  http://www.w3id.org/ecsel-dr-Planning#Strict_Hierarchical_Situation
 ecsel-dr-Planning:Strict_Hierarchical_Situation rdf:type owl:Class ;
                                                 rdfs:subClassOf ecsel-dr-Planning:Hierarchical_Situation ;
-                                                rdfs:comment "There are only edges between vertices of level k and vertices of level k-1, where k≥2." .
+                                                rdfs:label "Strict Hierarchical Situation"@en ;
+                                                skos:definition """Strict Hierarchical Situation is a structured scenario, organisational framework, or system state within the semiconductor supply chain in which all entities, processes, or decisions follow a rigid hierarchy characterised by clear, predefined levels of authority, responsibility, or dependency. In such situations, relationships between entities, such as resources, processes, operations, or managerial roles, are strictly governed by vertical or layered structures, where lower level elements depend on or are constrained by higher level elements."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning#Substitution
@@ -22564,7 +22565,7 @@ ecsel-dr-Planning:Yield rdf:type owl:Class ;
 <http://www.w3id.org/ecsel-dr-Planning-SCP#AP_FCST> rdf:type owl:Class ;
                                                     rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Forecast> ;
                                                     rdfs:label "AP FCST"@en ;
-                                                    skos:definition "Allocation Priority Forecast" .
+                                                    skos:definition """Allocation Priority Forecast. To be used in case of too high order picture on special products. The system should usually consider the amount of the entered run rates only. AP_FCST is usually the highest priority in capacity planning."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Aggregated_Capacity
@@ -22676,8 +22677,10 @@ customers are central to both demand creation in the supply chain and the fulfil
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#HP_Forecast
 <http://www.w3id.org/ecsel-dr-Planning-SCP#HP_Forecast> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Forecast> ;
-                                                        rdfs:label "HP Forecast"@en .
+                                                        rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Forecast> ,
+                                                                        <http://www.w3id.org/ecsel-dr-Planning-SCP#Operational_Demand> ;
+                                                        rdfs:label "HP Forecast"@en ;
+                                                        skos:definition """High Priority Forecast is an implicitly expected, internally generated demand signal of the highest priority. It is used in supply chain planning under constrained supply conditions to strategically reserve and protect generated supply ahead of order confirmation. Demand planned from HP_FCST is not allocated to specific customer orders automatically, but is held for strategic distribution decisions, such as serving preferred customers or fulfilling high value demand. As a subclass of Operational_Demand, it represents an implicit expected customer need, originating from an internal business division rather than a direct customer order."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Marketing_Demand
@@ -22712,14 +22715,15 @@ customers are central to both demand creation in the supply chain and the fulfil
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#NP_Forecast
 <http://www.w3id.org/ecsel-dr-Planning-SCP#NP_Forecast> rdf:type owl:Class ;
                                                         rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Forecast> ;
-                                                        rdfs:label "NP Forecast"@en .
+                                                        rdfs:label "NP Forecast"@en ;
+                                                        skos:definition """Normal Priority Forecast. To be used for quantity reservation that orders from other products can consume. To be used if not clear if an order might come. Orders from other products can push these booked quantities and use this capacity just in time. Priority is lower than an order; a mix with other forecasts is possible."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#OP_Forecast
 <http://www.w3id.org/ecsel-dr-Planning-SCP#OP_Forecast> rdf:type owl:Class ;
                                                         rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Forecast> ;
                                                         rdfs:label "OP Forecast"@en ;
-                                                        skos:definition "Order Priority Forecast" .
+                                                        skos:definition """Order Priority Forecast. To be used for quantity reservations that should not be consumed by orders of other products, for example earlier entering. Orders from other products cannot consume into this booked quantity of capacity. Priority is higher than an order; a mix with other forecasts is possible."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Open_Order_Book
@@ -22774,7 +22778,8 @@ customers are central to both demand creation in the supply chain and the fulfil
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Private_Customer
 <http://www.w3id.org/ecsel-dr-Planning-SCP#Private_Customer> rdf:type owl:Class ;
                                                              rdfs:subClassOf dr:Customer ;
-                                                             rdfs:label "Private Customers"@en .
+                                                             rdfs:label "Private Customers"@en ;
+                                                             skos:definition """Private Customer is an entity, such as a business, organisation, or individual, that engages in a direct and often exclusive transactional relationship with a semiconductor manufacturer, supplier, or service provider. This customer typically operates outside of the public marketplace or general distribution channels, relying on custom solutions, specialised services, or dedicated resources tailored to meet specific requirements."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Promise
@@ -22788,8 +22793,7 @@ customers are central to both demand creation in the supply chain and the fulfil
 <http://www.w3id.org/ecsel-dr-Planning-SCP#Ramp_Up_Stock> rdf:type owl:Class ;
                                                           rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks> ;
                                                           rdfs:label "Ramp Up Stock"@en ;
-                                                          skos:definition "Ramp up stock targets are used when ramping new products. Often there are no orders yet in the system, but the RSM already wants some chips on DIEBANK or finished goods on VKL." .
-
+                                                          skos:definition """Ramp Up Stock is a subclass of inventory stock targets used in supply chain planning to build up a buffer of finished goods or intermediate components ahead of a new product launch. It is applied in situations where customer orders have not yet entered the system, but the supply planning team wants physical inventory pre positioned and available in anticipation of future demand. As part of the broader family of stock targets, it functions as a proactive, forward looking inventory measure, distinct from safety or maximum stock targets, specifically designed to support the early stage ramp of new products and ensure supply readiness before commercial demand materializes."""@en .
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Resource_Capacity
 <http://www.w3id.org/ecsel-dr-Planning-SCP#Resource_Capacity> rdf:type owl:Class ;
@@ -22802,13 +22806,14 @@ customers are central to both demand creation in the supply chain and the fulfil
 <http://www.w3id.org/ecsel-dr-Planning-SCP#Retained_Stock> rdf:type owl:Class ;
                                                            rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks> ;
                                                            rdfs:label "Retained Stock"@en ;
-                                                           skos:definition "In allocation time, to compensate unplanned supply fluctuations e.g. short time demand increase or unexpected low deliveries from BE, an extra operational buffer is needed at DC. AP_FC targets defined by the SCP need to be produced regardless of the height of this operational buffer. This is enabled by hiding parts of the stock available in DC from the demand supply match. The operational buffer is called retain stock." .
+                                                           skos:definition """Retained Stock is a subclass of SSO Stocks representing an operational inventory buffer held at a distribution center to absorb unplanned supply fluctuations, such as short term demand increases or unexpectedly low inbound deliveries. As part of the broader SSO Stocks family, which governs strategic stock profiles at the finished goods level, Retained Stock works by temporarily hiding a portion of the available on hand inventory from the active demand supply matching process. This ensures that planned production or replenishment targets are pursued regardless of the current buffer level, preserving supply continuity without requiring manual intervention in the planning cycle."""@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks
 <http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks> rdf:type owl:Class ;
                                                        rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Operational_Demand> ;
-                                                       rdfs:label "SSO Stocks"@en .
+                                                       rdfs:label "SSO Stocks"@en ;
+
 
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Safety_Stock
@@ -22816,7 +22821,7 @@ customers are central to both demand creation in the supply chain and the fulfil
                                                          rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks> ;
                                                          rdfs:comment "Describes a level of extra stock that is maintained to mitigate risk of stockouts  caused by uncertainties in supply and demand."@en ;
                                                          rdfs:label "Safety Stock"@en .
-
+                                                         skos:definition """SSO Stocks refers to SSO stock profiles applied exclusively at the finished goods level, sourced from Stockplan Rules or manually entered in the SPL UI. This class encompasses three subtypes: Retained Stock, which is handled together with AP_FCST settings via retain stock rules; Min Stock, representing the minimum inventory level desired on hand to buffer small capacity problems; and Max Stock, representing the maximum inventory level permitted, used to fill capacities."""@en .
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Sales_Demand
 <http://www.w3id.org/ecsel-dr-Planning-SCP#Sales_Demand> rdf:type owl:Class ;
@@ -23652,7 +23657,7 @@ ecsel-dr-RAMI40:Machine rdf:type owl:Class ;
                         rdfs:subClassOf ecsel-dr-RAMI40:Asset ;
                         rdfs:label "Machine"@en ;
                         skos:definition "A machine is ordered, designed, commissioned, operated, serviced, converted and recycled."@en ;
-                        skos:preLabel "Machine"@en .
+                        skos:prefLabel "Machine"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-RAMI40#Measure
@@ -23707,7 +23712,7 @@ ecsel-dr-RAMI40:RAMI_Life_Cycle_Dimension rdf:type owl:Class ;
                                           rdfs:label "RAMI Life Cycle Dimension"@en ;
                                           rdfs:seeAlso "http://www.zvei.org/en/subjects/Industry-40/Pages/The-Reference-Architectural-Model-RAMI-40-and-the-Industrie-40-Component.aspx" ;
                                           skos:definition "It describes the different Life Cycle and Value Stream layers for the RAMI model according to the IEC 62890 Standard." ;
-                                          skos:preLabel "RAMI Layer" ,
+                                          skos:prefLabel "RAMI Layer" ,
                                                         "RAMI Life Cycle Dimension" .
 
 
@@ -23744,7 +23749,7 @@ ecsel-dr-RAMI40:Standard rdf:type owl:Class ;
                          rdfs:isDefinedBy <https://w3id.org/i40/sto/#Standard> ;
                          rdfs:label "Standard"@en ;
                          skos:definition "Standards that are used to describe the actual I4.0 Asset. Defined in the STO ontology"@en ;
-                         skos:preLabel "Standard"@en .
+                         skos:prefLabel "Standard"@en .
 
 
 ###  http://www.w3id.org/ecsel-dr-RAMI40#Standard_Organization

--- a/DigitalReference.ttl
+++ b/DigitalReference.ttl
@@ -22813,6 +22813,7 @@ customers are central to both demand creation in the supply chain and the fulfil
 <http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks> rdf:type owl:Class ;
                                                        rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#Operational_Demand> ;
                                                        rdfs:label "SSO Stocks"@en ;
+                                                       skos:definition """SSO Stocks refers to SSO stock profiles applied exclusively at the finished goods level, sourced from Stockplan Rules or manually entered in the SPL UI. This class encompasses three subtypes: Retained Stock, which is handled together with AP_FCST settings via retain stock rules; Min Stock, representing the minimum inventory level desired on hand to buffer small capacity problems; and Max Stock, representing the maximum inventory level permitted, used to fill capacities."""@en .
 
 
 
@@ -22821,7 +22822,7 @@ customers are central to both demand creation in the supply chain and the fulfil
                                                          rdfs:subClassOf <http://www.w3id.org/ecsel-dr-Planning-SCP#SSO_Stocks> ;
                                                          rdfs:comment "Describes a level of extra stock that is maintained to mitigate risk of stockouts  caused by uncertainties in supply and demand."@en ;
                                                          rdfs:label "Safety Stock"@en .
-                                                         skos:definition """SSO Stocks refers to SSO stock profiles applied exclusively at the finished goods level, sourced from Stockplan Rules or manually entered in the SPL UI. This class encompasses three subtypes: Retained Stock, which is handled together with AP_FCST settings via retain stock rules; Min Stock, representing the minimum inventory level desired on hand to buffer small capacity problems; and Max Stock, representing the maximum inventory level permitted, used to fill capacities."""@en .
+                                                         
 
 ###  http://www.w3id.org/ecsel-dr-Planning-SCP#Sales_Demand
 <http://www.w3id.org/ecsel-dr-Planning-SCP#Sales_Demand> rdf:type owl:Class ;


### PR DESCRIPTION
This PR fixes several ontology issues that were causing problems in the learning tool:

- Updated the OWL-Time day_of_week issue so that day_of_week remains an object property and DayOfWeek is used as the class.
- Renamed the duplicated DF datatype property from has_order_position to has_order_position_value, while keeping has_order_position as the object property.
- Removed the self-subclass axiom from SO Technology.
- Removed explicit ^^rdfs:Literal datatypes from affected rdfs:comment annotations.
- Also removed the duplicated time_zone class declaration that caused the same class/object property overlap pattern.

I checked the ontology in Protégé using SPARQL queries for:
- entities declared as both owl:Class and owl:ObjectProperty
- properties declared as both owl:ObjectProperty and owl:DatatypeProperty
- self-subclass axioms

All three checks now return no results.
